### PR TITLE
[Bug] #1  Corregir rutas duplicadas y registrar login como @action en AuthViewSet

### DIFF
--- a/users/urls.py
+++ b/users/urls.py
@@ -46,13 +46,10 @@ urlpatterns = [
     # Health check endpoint
     path('health/', HealthCheckView.as_view(), name='health-check'),
     
-    # Auth endpoints
+    # Auth endpoints — todas generadas por el router vía @action
     path('', include(router.urls)),
-    
-    # Ruta custom para login (usando action)
-    path('auth/login/', AuthViewSet.as_view({'post': 'login'}), name='auth-login'),
-    path('auth/me/', AuthViewSet.as_view({'get': 'me'}), name='auth-me'),
-    path('auth/logout/', AuthViewSet.as_view({'post': 'logout'}), name='auth-logout'),
+
+    # Token refresh — CookieTokenRefreshView no pertenece al ViewSet
     path('auth/refresh/', CookieTokenRefreshView.as_view(), name='token_refresh'),
 ]
 

--- a/users/views.py
+++ b/users/views.py
@@ -263,6 +263,7 @@ class AuthViewSet(viewsets.ViewSet):
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR
             )
     
+    @action(detail=False, methods=['post'], url_path='login', permission_classes=[AllowAny])
     def login(self, request):
         """
         POST /api/auth/login/


### PR DESCRIPTION
## Resumen
Elimina las tres rutas explícitas redundantes (auth/login/, auth/me/, auth/logout/) del urlpatterns y decora el método login con @action para que el router lo gestione.

## Issue relacionado
Fixes #1

## Cambios
- users/urls.py: eliminadas rutas manuales
- users/views.py: decorador @action añadido a login

## Quality Gate
- [x] SOLID verificado
- [x] Sin code smells
- [x] Commits atómicos Conventional Commits