### PR TITLE
[Bug] #2  Reemplazar DefaultRouter por SimpleRouter para eliminar rutas 405 fantasmas

### DIFF
--- a/users/urls.py
+++ b/users/urls.py
@@ -32,11 +32,13 @@ Define las rutas de la API REST.
 """
 
 from django.urls import path, include
-from rest_framework.routers import DefaultRouter
+from rest_framework.routers import SimpleRouter
 from .views import HealthCheckView, AuthViewSet, CookieTokenRefreshView
 
 # Router para ViewSets
-router = DefaultRouter()
+# Se usa SimpleRouter (en lugar de DefaultRouter) para no exponer rutas de
+# list/retrieve/update/destroy que no están implementadas en AuthViewSet.
+router = SimpleRouter()
 
 # Registrar AuthViewSet
 # Las rutas create() se mapean a POST /api/auth/


### PR DESCRIPTION
## Resumen
Reemplaza DefaultRouter por SimpleRouter para no exponer list/retrieve/update/partial_update/destroy que retornan 405 en AuthViewSet.

## Issue relacionado
Fixes #2

## Cambios
- users/urls.py: SimpleRouter en lugar de DefaultRouter

## Quality Gate
- [x] SOLID verificado
- [x] Sin code smells
- [x] Commits atómicos Conventional Commits