### PR TITLE
[Bug] #3  by-role retorna 400 para roles invalidos en lugar de 200 vacio

### DIFF
--- a/users/application/use_cases.py
+++ b/users/application/use_cases.py
@@ -14,7 +14,7 @@ from ..domain.factories import UserFactory
 from ..domain.repositories import UserRepository
 from ..domain.event_publisher import EventPublisher
 from ..domain.events import UserCreated, UserDeactivated
-from ..domain.exceptions import UserAlreadyExists, UserNotFound
+from ..domain.exceptions import UserAlreadyExists, UserNotFound, InvalidRole
 
 
 def _generate_tokens(user: User) -> dict[str, str]:
@@ -489,7 +489,7 @@ class GetUsersByRoleUseCase:
             try:
                 role = UserRole[role_text]
             except KeyError:
-                return []
+                raise InvalidRole(role_text)
         
         # Obtener usuarios por rol
         return self.repository.find_by_role(role)

--- a/users/domain/exceptions.py
+++ b/users/domain/exceptions.py
@@ -52,3 +52,15 @@ class UserNotFound(DomainException):
 class InvalidUserData(DomainException):
     """Se lanza cuando los datos del usuario son inválidos."""
     pass
+
+
+class InvalidRole(DomainException):
+    """Se lanza cuando el rol proporcionado no existe en el sistema."""
+
+    VALID_ROLES = ['ADMIN', 'USER']
+
+    def __init__(self, role: str):
+        self.role = role
+        super().__init__(
+            f"Rol inválido: {role}. Valores permitidos: {', '.join(self.VALID_ROLES)}"
+        )

--- a/users/views.py
+++ b/users/views.py
@@ -153,7 +153,8 @@ from .domain.exceptions import (
     InvalidEmail,
     InvalidUsername,
     InvalidUserData,
-    UserNotFound
+    UserNotFound,
+    InvalidRole,
 )
 
 
@@ -359,7 +360,12 @@ class AuthViewSet(viewsets.ViewSet):
             ]
             
             return Response(users_data, status=status.HTTP_200_OK)
-        
+
+        except InvalidRole as e:
+            return Response(
+                {'error': str(e)},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         except Exception as e:
             return Response(
                 {'error': f'Error inesperado: {str(e)}'},


### PR DESCRIPTION
## Resumen
Corrige GET /api/auth/by-role/{role}/ que retornaba 200 OK [] para roles inexistentes. Ahora retorna 400 Bad Request con mensaje descriptivo.

## Issue relacionado
Fixes #3

## Cambios
- domain/exceptions.py: nueva excepcion InvalidRole
- use_cases.py: GetUsersByRoleUseCase lanza InvalidRole para roles invalidos
- views.py: captura InvalidRole y retorna 400

## Quality Gate
- [x] SOLID verificado
- [x] Sin code smells
- [x] Commits atomicos Conventional Commits