### PR TITLE
[Bug] #17 — Corregir errores en test_use_cases.py que impiden la ejecución de tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = user_service.settings


### PR DESCRIPTION
## 📋 Summary
Agrega el archivo `pytest.ini` faltante en la raíz del proyecto para que `pytest` configure correctamente `DJANGO_SETTINGS_MODULE` antes de recolectar los tests.

La segunda parte del issue (aserción incorrecta en `test_execute_creates_user_with_user_role`) ya estaba corregida en `develop` — la línea ya usa `result['user'].role` en lugar de `result.role`.

## 🔗 Related Issue
Fixes #17

## 🔄 Changes
- **Nuevo archivo `pytest.ini`**: define `DJANGO_SETTINGS_MODULE = user_service.settings` para que `pytest` pueda recolectar y ejecutar tests de Django sin errores de configuración.

## ✅ Quality Gate
- [x] SOLID principles verified
- [x] No code smells detected
- [x] Atomic commits with Conventional Commits format

## 📝 Notes
- No se requiere migración ni cambios de despliegue.
- El archivo solo afecta la ejecución local de tests con `pytest`.