### PR TITLE
[Bug] #29 — Eliminar imports no utilizados que rompen el CI (F401)

### DIFF
--- a/users/application/use_cases.py
+++ b/users/application/use_cases.py
@@ -14,7 +14,7 @@ from ..domain.entities import User, UserRole
 from ..domain.factories import UserFactory
 from ..domain.repositories import UserRepository
 from ..domain.event_publisher import EventPublisher
-from ..domain.events import UserCreated, UserDeactivated
+from ..domain.events import UserCreated
 from ..domain.exceptions import UserAlreadyExists, UserNotFound, InvalidCredentials, InvalidRole
 
 

--- a/users/domain/factories.py
+++ b/users/domain/factories.py
@@ -3,7 +3,6 @@ Factory - Crea instancias de entidades de dominio asegurando validez.
 Encapsula la lógica compleja de creación y validación.
 """
 
-import uuid
 import hashlib
 
 from .entities import User, UserRole

--- a/users/tests.py
+++ b/users/tests.py
@@ -1,3 +1,1 @@
-from django.test import TestCase
-
 # Create your tests here.

--- a/users/tests/test_domain.py
+++ b/users/tests/test_domain.py
@@ -13,7 +13,6 @@ from users.domain.exceptions import (
     InvalidUsername,
     InvalidUserData,
     UserAlreadyInactive,
-    UserNotFound
 )
 from users.domain.events import UserCreated, UserDeactivated, UserEmailChanged
 


### PR DESCRIPTION
## 📋 Summary
Elimina 4 imports no utilizados (F401) detectados por `flake8` en el pipeline de CI.

## 🔗 Related Issue
Fixes #29

## 🔄 Changes
- Removido `UserDeactivated` de `users/application/use_cases.py` (import no utilizado)
- Removido `uuid` de `users/domain/factories.py` (import no utilizado)
- Removido `django.test.TestCase` de `users/tests.py` (import no utilizado)
- Removido `UserNotFound` de `users/tests/test_domain.py` (import no utilizado)

## ✅ Quality Gate
- [x] SOLID principles verified (no behavior change)
- [x] No code smells detected
- [x] Atomic commits with Conventional Commits format
- [x] Verified with `flake8 --select=F401` — 0 errors

## 📝 Notes
Este PR solo corrige imports no utilizados. Los errores restantes de flake8 (W293/W291, E231/E302/E402) se abordan en PRs separados (#28, #30).