### PR TITLE
[Bug] #30 — Corregir errores de formato y orden de imports en el CI (E231/E302/E402)

### DIFF
--- a/users/domain/entities.py
+++ b/users/domain/entities.py
@@ -201,7 +201,7 @@ class User:
             email=email.lower().strip(),
             username=username.strip(),
             password_hash=password_hash,
-            is_active=True,role=role,
+            is_active=True, role=role,
             created_at=datetime.now()
         )
         

--- a/users/domain/exceptions.py
+++ b/users/domain/exceptions.py
@@ -64,6 +64,8 @@ class InvalidCredentials(DomainException):
     def __init__(self, reason: str = "Credenciales inválidas"):
         self.reason = reason
         super().__init__(reason)
+
+
 class InvalidRole(DomainException):
     """Se lanza cuando el rol proporcionado no existe en el sistema."""
 

--- a/users/messaging/consumer.py
+++ b/users/messaging/consumer.py
@@ -18,8 +18,8 @@ sys.path.insert(0, base_dir)
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "user_service.settings")
 django.setup()
 
-import pika
-import json
+import pika  # noqa: E402
+import json  # noqa: E402
 
 # Configuración RabbitMQ desde variables de entorno
 RABBIT_HOST = os.environ.get('RABBITMQ_HOST', 'rabbitmq')

--- a/users/views.py
+++ b/users/views.py
@@ -136,8 +136,6 @@ from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework_simplejwt.exceptions import TokenError
 from django.db import connection
 
-logger = logging.getLogger(__name__)
-
 from .application.use_cases import (
     RegisterUserCommand,
     LoginCommand,
@@ -170,6 +168,8 @@ from .domain.exceptions import (
     InvalidCredentials,
     InvalidRole,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class HealthCheckView(APIView):


### PR DESCRIPTION
## 📋 Summary
Corrige errores de formato de código y orden de imports (E231, E302, E402) detectados por `flake8` en el pipeline de CI.

## 🔗 Related Issue
Fixes #30

## 🔄 Changes
- **E231** — Agregado espacio después de coma en `users/domain/entities.py:204` (`is_active=True,role=role` → `is_active=True, role=role`)
- **E302** — Agregadas 2 líneas en blanco antes de `class InvalidRole` en `users/domain/exceptions.py:67`
- **E402** — Movido `logger = logging.getLogger(__name__)` después de todos los imports en `users/views.py` para que los imports locales queden al nivel superior
- **E402** — Agregado `# noqa: E402` en imports de `pika` y `json` en `users/messaging/consumer.py` (son intencionalmente posteriores a `django.setup()`)

## ✅ Quality Gate
- [x] SOLID principles verified (no behavior change)
- [x] No code smells detected
- [x] Atomic commits with Conventional Commits format
- [x] Verified with `flake8 --select=E231,E302,E402` — 0 errors

## 📝 Notes
Este PR completa la corrección de todos los errores de flake8 del CI junto con #28 (whitespace) y #29 (imports no utilizados). Una vez mergeados los 3 PRs, el paso Lint & Style del CI debería pasar correctamente.