### PR TITLE
[Bug] #34 — Corregir tests de dominio que no incluyen parámetro 'role' en User

### DIFF
--- a/users/tests/test_domain.py
+++ b/users/tests/test_domain.py
@@ -6,7 +6,7 @@ Prueban reglas de negocio, entidades, factories y excepciones.
 import pytest
 from datetime import datetime
 
-from users.domain.entities import User
+from users.domain.entities import User, UserRole
 from users.domain.factories import UserFactory
 from users.domain.exceptions import (
     InvalidEmail,
@@ -44,6 +44,7 @@ class TestUserEntity:
                 username="testuser",
                 password_hash="hash",
                 is_active=True,
+                role=UserRole.USER,
                 created_at=datetime.now()
             )
 
@@ -56,6 +57,7 @@ class TestUserEntity:
                 username="testuser",
                 password_hash="hash",
                 is_active=True,
+                role=UserRole.USER,
                 created_at=datetime.now()
             )
 
@@ -68,6 +70,7 @@ class TestUserEntity:
                 username="",
                 password_hash="hash",
                 is_active=True,
+                role=UserRole.USER,
                 created_at=datetime.now()
             )
 
@@ -79,6 +82,7 @@ class TestUserEntity:
             username="testuser",
             password_hash="hash",
             is_active=True,
+            role=UserRole.USER,
             created_at=datetime.now()
         )
 
@@ -99,6 +103,7 @@ class TestUserEntity:
             username="testuser",
             password_hash="hash",
             is_active=False,
+            role=UserRole.USER,
             created_at=datetime.now()
         )
 
@@ -116,6 +121,7 @@ class TestUserEntity:
             username="testuser",
             password_hash="hash",
             is_active=True,
+            role=UserRole.USER,
             created_at=datetime.now()
         )
 
@@ -134,6 +140,7 @@ class TestUserEntity:
             username="testuser",
             password_hash="hash",
             is_active=True,
+            role=UserRole.USER,
             created_at=datetime.now()
         )
 
@@ -155,6 +162,7 @@ class TestUserEntity:
             username="testuser",
             password_hash="hash",
             is_active=True,
+            role=UserRole.USER,
             created_at=datetime.now()
         )
 
@@ -169,6 +177,7 @@ class TestUserEntity:
             username="testuser",
             password_hash="hash",
             is_active=True,
+            role=UserRole.USER,
             created_at=datetime.now()
         )
 
@@ -186,6 +195,7 @@ class TestUserEntity:
             username="testuser",
             password_hash="hash",
             is_active=True,
+            role=UserRole.USER,
             created_at=datetime.now()
         )
 
@@ -205,6 +215,7 @@ class TestUserEntity:
             username="testuser",
             password_hash="hash",
             is_active=True,
+            role=UserRole.USER,
             created_at=datetime.now()
         )
 


### PR DESCRIPTION
## 📋 Summary
Corrige los 11 tests fallidos en `TestUserEntity` dentro de `users/tests/test_domain.py` que creaban instancias de `User` sin el parámetro obligatorio `role`, agregado en la entidad como `UserRole`.

## 🔗 Related Issue
Fixes #34

## 🔄 Changes
- Agregado `from users.domain.entities import User, UserRole` (se añade `UserRole` al import)
- Agregado `role=UserRole.USER` en las 11 instanciaciones directas de `User()` en `TestUserEntity` que carecían de este parámetro

### Tests afectados:
1. `test_user_validates_email_format_on_creation`
2. `test_user_validates_empty_email`
3. `test_user_validates_empty_username`
4. `test_deactivate_user_changes_status_and_generates_event`
5. `test_cannot_deactivate_inactive_user`
6. `test_deactivate_is_idempotent_but_throws`
7. `test_change_email_updates_email_and_generates_event`
8. `test_change_email_validates_format`
9. `test_change_email_is_idempotent`
10. `test_multiple_operations_generate_multiple_events`
11. `test_collect_domain_events_clears_list`

## ✅ Quality Gate
- [x] SOLID principles verified
- [x] No code smells detected
- [x] Atomic commits with Conventional Commits format

## 📝 Notes
- Los tests de `TestUserFactory` y `TestDomainEvents` no requerían cambios porque usan `UserFactory.create()` o no instancian `User` directamente
- El error era: `TypeError: User.__init__() missing 1 required positional argument: 'role'`