### PR TITLE
[Refactor] #43 — Mover imágenes fuera de las tablas en TEST_PLAN.md

### DIFF
--- a/TEST_PLAN.md
+++ b/TEST_PLAN.md
@@ -413,19 +413,41 @@ De acuerdo con la identificación de riesgos en la sección 7, las pruebas se ab
 | ID | Escenario | Método | Endpoint | Datos de Entrada | Resultado Esperado | Status |
 |----|-----------|--------|----------|------------------|--------------------|--------|
 | INT-REG-001 | Registro exitoso con datos válidos | `POST` | `/api/auth/` | `{"email": "nuevo@test.com", "username": "nuevo", "password": "password123"}` | Respuesta con `user.role = "USER"`, cookies JWT establecidas | `201` |
-![alt text](images/image.png)
 | INT-REG-002 | Registro rechaza email duplicado | `POST` | `/api/auth/` | Email ya existente | `{"error": "Ya existe un usuario con el email: ..."}` | `400` |
-![alt text](images/image-1.png)
 | INT-REG-003 | Registro rechaza password < 8 chars | `POST` | `/api/auth/` | `{"password": "short"}` | Error de validación | `400` |
-![alt text](images/image-2.png)
 | INT-REG-004 | Registro rechaza username < 3 chars | `POST` | `/api/auth/` | `{"username": "ab"}` | Error de validación | `400` |
-![alt text](images/image-3.png)
 | INT-REG-005 | Registro rechaza email inválido | `POST` | `/api/auth/` | `{"email": "no-es-email"}` | Error de validación | `400` |
-![alt text](images/image-4.png)
 | INT-REG-006 | Registro ignora campo role (seguridad) | `POST` | `/api/auth/` | `{"role": "ADMIN", ...datos válidos}` | `user.role = "USER"` (no ADMIN) | `201` |
-![alt text](images/image-5.png)
 | INT-REG-007 | Registro establece cookies HttpOnly | `POST` | `/api/auth/` | Datos válidos | Cookies `access_token` y `refresh_token` presentes, `HttpOnly=True` | `201` |
-![alt text](images/image-6.png)
+
+**INT-REG-001** — Registro exitoso con datos válidos
+
+![INT-REG-001](images/image.png)
+
+**INT-REG-002** — Registro rechaza email duplicado
+
+![INT-REG-002](images/image-1.png)
+
+**INT-REG-003** — Registro rechaza password < 8 chars
+
+![INT-REG-003](images/image-2.png)
+
+**INT-REG-004** — Registro rechaza username < 3 chars
+
+![INT-REG-004](images/image-3.png)
+
+**INT-REG-005** — Registro rechaza email inválido
+
+![INT-REG-005](images/image-4.png)
+
+**INT-REG-006** — Registro ignora campo role (seguridad)
+
+![INT-REG-006](images/image-5.png)
+
+**INT-REG-007** — Registro establece cookies HttpOnly
+
+![INT-REG-007](images/image-6.png)
+
 ---
 
 ### 6.3 US-002: Login de Usuario (`POST /api/auth/login/`)
@@ -433,19 +455,40 @@ De acuerdo con la identificación de riesgos en la sección 7, las pruebas se ab
 | ID | Escenario | Método | Endpoint | Datos de Entrada | Resultado Esperado | Status |
 |----|-----------|--------|----------|------------------|--------------------|--------|
 | INT-LOG-001 | Login exitoso con credenciales válidas | `POST` | `/api/auth/login/` | `{"email": "nuevo@test.com", "password": "password123"}` | Respuesta con `user.id`, `email`, `username`, `role` | `200` |
-![alt text](images/image-7.png)
 | INT-LOG-002 | Login establece cookies JWT | `POST` | `/api/auth/login/` | Credenciales válidas | Cookies `access_token`, `refresh_token` con `HttpOnly` | `200` |
-![alt text](images/image-8.png)
 | INT-LOG-003 | Login fallido con password incorrecto | `POST` | `/api/auth/login/` | `{"password": "wrongpass"}` | `{"error": "Credenciales inválidas"}` | `401` |
-![alt text](images/image-9.png)
 | INT-LOG-004 | Login fallido con email inexistente | `POST` | `/api/auth/login/` | `{"email": "noexiste@test.com"}` | `{"error": "Credenciales inválidas"}` | `401` |
-![alt text](images/image-10.png)
 | INT-LOG-005 | Login rechazado para usuario inactivo | `POST` | `/api/auth/login/` | Email de usuario desactivado | `{"error": "..."}` (usuario inactivo) | `401` |
-![alt text](images/image-11.png)
 | INT-LOG-006 | Login sin campo email (incompleto) | `POST` | `/api/auth/login/` | `{"password": "password123"}` | Error de validación serializer | `400` |
-![alt text](images/image-12.png)
 | INT-LOG-007 | Login sin campo password (incompleto) | `POST` | `/api/auth/login/` | `{"email": "user@test.com"}` | Error de validación serializer | `400` |
-![alt text](images/image-13.png)
+
+**INT-LOG-001** — Login exitoso con credenciales válidas
+
+![INT-LOG-001](images/image-7.png)
+
+**INT-LOG-002** — Login establece cookies JWT
+
+![INT-LOG-002](images/image-8.png)
+
+**INT-LOG-003** — Login fallido con password incorrecto
+
+![INT-LOG-003](images/image-9.png)
+
+**INT-LOG-004** — Login fallido con email inexistente
+
+![INT-LOG-004](images/image-10.png)
+
+**INT-LOG-005** — Login rechazado para usuario inactivo
+
+![INT-LOG-005](images/image-11.png)
+
+**INT-LOG-006** — Login sin campo email (incompleto)
+
+![INT-LOG-006](images/image-12.png)
+
+**INT-LOG-007** — Login sin campo password (incompleto)
+
+![INT-LOG-007](images/image-13.png)
 
 ---
 
@@ -454,10 +497,16 @@ De acuerdo con la identificación de riesgos en la sección 7, las pruebas se ab
 | ID | Escenario | Método | Endpoint | Datos de Entrada | Resultado Esperado | Status |
 |----|-----------|--------|----------|------------------|--------------------|--------|
 | INT-ME-001 | Perfil exitoso con JWT válido | `GET` | `/api/auth/me/` | Cookie `access_token` válida | `{"id", "email", "username", "role", "is_active"}` | `200` |
-![alt text](images/image-14.png)
 | INT-ME-002 | Perfil rechazado sin autenticación | `GET` | `/api/auth/me/` | Sin cookies JWT | Error de autenticación | `401` |
-![alt text](images/image-15.png)
 | INT-ME-003 | Perfil rechazado con token expirado | `GET` | `/api/auth/me/` | Cookie `access_token` expirada | Error de autenticación | `401` |
+
+**INT-ME-001** — Perfil exitoso con JWT válido
+
+![INT-ME-001](images/image-14.png)
+
+**INT-ME-002** — Perfil rechazado sin autenticación
+
+![INT-ME-002](images/image-15.png)
 
 ---
 
@@ -466,10 +515,17 @@ De acuerdo con la identificación de riesgos en la sección 7, las pruebas se ab
 | ID | Escenario | Método | Endpoint | Datos de Entrada | Resultado Esperado | Status |
 |----|-----------|--------|----------|------------------|--------------------|--------|
 | INT-OUT-001 | Logout exitoso limpia cookies | `POST` | `/api/auth/logout/` | Usuario autenticado | `{"detail": "Sesión cerrada"}`, cookies eliminadas | `200` |
-![alt text](images/image-16.png)
-![alt text](images/image-17.png)
 | INT-OUT-002 | Logout sin autenticación permitido | `POST` | `/api/auth/logout/` | Sin cookies | `{"detail": "Sesión cerrada"}` | `200` |
-![alt text](images/image-18.png)
+
+**INT-OUT-001** — Logout exitoso limpia cookies
+
+![INT-OUT-001 (request)](images/image-16.png)
+
+![INT-OUT-001 (cookies eliminadas)](images/image-17.png)
+
+**INT-OUT-002** — Logout sin autenticación permitido
+
+![INT-OUT-002](images/image-18.png)
 
 ---
 
@@ -478,13 +534,25 @@ De acuerdo con la identificación de riesgos en la sección 7, las pruebas se ab
 | ID | Escenario | Método | Endpoint | Datos de Entrada | Resultado Esperado | Status |
 |----|-----------|--------|----------|------------------|--------------------|--------|
 | INT-ROL-001 | Usuarios con rol ADMIN | `GET` | `/api/auth/by-role/ADMIN/` | JWT válido | Lista donde todos tienen `role: "ADMIN"` | `200` |
-![alt text](images/image-19.png)
 | INT-ROL-002 | Usuarios con rol USER | `GET` | `/api/auth/by-role/USER/` | JWT válido | Lista donde todos tienen `role: "USER"` | `200` |
-![alt text](images/image-20.png)
 | INT-ROL-003 | Rol inválido retorna error | `GET` | `/api/auth/by-role/SUPERADMIN/` | JWT válido | `{"error": "Rol inválido: SUPERADMIN..."}` | `400` |
-![alt text](images/image-21.png)
 | INT-ROL-004 | Sin autenticación rechazado | `GET` | `/api/auth/by-role/USER/` | Sin JWT | Error de autenticación | `401` |
-![alt text](images/image-22.png)
+
+**INT-ROL-001** — Usuarios con rol ADMIN
+
+![INT-ROL-001](images/image-19.png)
+
+**INT-ROL-002** — Usuarios con rol USER
+
+![INT-ROL-002](images/image-20.png)
+
+**INT-ROL-003** — Rol inválido retorna error
+
+![INT-ROL-003](images/image-21.png)
+
+**INT-ROL-004** — Sin autenticación rechazado
+
+![INT-ROL-004](images/image-22.png)
 
 ---
 
@@ -493,11 +561,20 @@ De acuerdo con la identificación de riesgos en la sección 7, las pruebas se ab
 | ID | Escenario | Método | Endpoint | Datos de Entrada | Resultado Esperado | Status |
 |----|-----------|--------|----------|------------------|--------------------|--------|
 | INT-REF-001 | Refresh exitoso con cookie válida | `POST` | `/api/auth/refresh/` | Cookie `refresh_token` válida | `{"detail": "Token renovado"}`, nuevas cookies | `200` |
-![alt text](images/image-23.png)
 | INT-REF-002 | Refresh sin cookie refresh_token | `POST` | `/api/auth/refresh/` | Sin cookie | `{"error": "Refresh token no encontrado"}` | `401` |
-![alt text](images/image-25.png)
 | INT-REF-003 | Refresh con token inválido | `POST` | `/api/auth/refresh/` | Cookie `refresh_token` corrupta | `{"error": "Refresh token inválido o expirado"}` | `401` |
-![alt text](images/image-24.png)
+
+**INT-REF-001** — Refresh exitoso con cookie válida
+
+![INT-REF-001](images/image-23.png)
+
+**INT-REF-002** — Refresh sin cookie refresh_token
+
+![INT-REF-002](images/image-25.png)
+
+**INT-REF-003** — Refresh con token inválido
+
+![INT-REF-003](images/image-24.png)
 
 ---
 


### PR DESCRIPTION
## 📋 Summary
Las imágenes de evidencia estaban intercaladas entre filas de tablas Markdown en la sección 6 del `TEST_PLAN.md`, rompiendo el renderizado. Se mueven debajo de cada tabla, identificadas por el ID del caso de prueba correspondiente.

## 🔗 Related Issue
Fixes #43

## 🔄 Changes
- Sección 6.2 (Registro): 7 imágenes (image.png a image-6.png) movidas debajo de la tabla completa con etiquetas `INT-REG-001` a `INT-REG-007`
- Sección 6.3 (Login): 7 imágenes (image-7.png a image-13.png) movidas debajo de la tabla con etiquetas `INT-LOG-001` a `INT-LOG-007`
- Sección 6.4 (Me): 2 imágenes (image-14.png, image-15.png) movidas debajo de la tabla con etiquetas `INT-ME-001` a `INT-ME-002`
- Sección 6.5 (Logout): 3 imágenes (image-16.png, image-17.png, image-18.png) movidas debajo de la tabla con etiquetas `INT-OUT-001` a `INT-OUT-002`
- Sección 6.6 (By-role): 4 imágenes (image-19.png a image-22.png) movidas debajo de la tabla con etiquetas `INT-ROL-001` a `INT-ROL-004`
- Sección 6.7 (Refresh): 3 imágenes (image-23.png, image-24.png, image-25.png) movidas debajo de la tabla con etiquetas `INT-REF-001` a `INT-REF-003`

## ✅ Quality Gate
- [x] SOLID principles verified
- [x] No code smells detected
- [x] Atomic commits con formato Conventional Commits (`docs(test-plan): mover imagenes fuera de tablas en seccion 6`)

## 📝 Notes
Cambio exclusivo de documentación — no afecta código fuente ni tests.
