### PR TITLE
[Chore] #45 — Agregar workflow de publicación de imagen Docker en GHCR

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,63 @@
+# =============================================================================
+# Publish Docker Image — Backend Users Service
+# =============================================================================
+# Construye la imagen Docker y la publica en GitHub Container Registry (GHCR).
+#
+# Tags generados:
+#   - latest     (solo desde main)
+#   - develop    (solo desde develop)
+#   - v1.2.3     (desde tags semver)
+#   - sha-abc123 (siempre)
+#
+# Para que el repo infra pueda usar:
+#   image: ghcr.io/equipo-6-uruguay/backend-users-service:latest
+# =============================================================================
+
+name: Publish Docker Image
+
+on:
+  push:
+    branches:
+      - develop
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    name: Build & Push to GHCR
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## 📋 Summary
Agrega el workflow `publish.yml` de GitHub Actions para construir y publicar automáticamente la imagen Docker del servicio de usuarios en GitHub Container Registry (GHCR).

## 🔗 Related Issue
Fixes #45

## 🔄 Changes
- Nuevo archivo `.github/workflows/publish.yml`
- Se dispara en push a `develop` y en tags semver (`v*`)
- Genera tags: branch ref, sha, semver (`{{version}}` y `{{major}}.{{minor}}`), y `latest` en rama principal
- Publica en `ghcr.io/equipo-6-uruguay/backend-users-service`

## ✅ Quality Gate
- [x] SOLID principles verified
- [x] No code smells detected
- [x] Atomic commits with Conventional Commits format

## 📝 Notes
El workflow usa `GITHUB_TOKEN` automático — no se requiere configurar secretos adicionales. El permiso `packages: write` está declarado explícitamente para poder publicar en GHCR.
